### PR TITLE
Fix: Correct OutOfFunds error in loan cycle test

### DIFF
--- a/test/Lendscape.t.sol
+++ b/test/Lendscape.t.sol
@@ -43,6 +43,9 @@ contract LendscapeTest is Test {
 
         // Give Alice (Lender) some ETH to fund the loan
         vm.deal(alice_lender, 5 ether);
+
+        // Give Bob (Borrower) some ETH to make the repayment + gas
+        vm.deal(bob_borrower, 1 ether);
     }
 
     /**


### PR DESCRIPTION
The `test_full_loan_cycle_success` test was failing due to the borrower not having sufficient funds to repay the loan. This was because the borrower's initial balance was not explicitly set.

This commit addresses the issue by:
- Adding `vm.deal(bob_borrower, 1 ether);` in the `setUp` function of `test/Lendscape.t.sol`. This ensures `bob_borrower` has enough ETH to cover the loan repayment amount.

All tests now pass after this change.